### PR TITLE
Name sensors by destination and expose stop coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ hinzufügen** und wähle **VBB Public Transport** aus. Gib die gewünschte
 Haltestellen-ID (z. B. `900000003201` für Berlin Hauptbahnhof) sowie einen
 Namen an.
 
-Für jede Linie und Richtung an der Haltestelle wird ein eigener Sensor
-angelegt (z. B. `S7_1` und `S7_2`). Der Sensor zeigt die Zeit der nächsten
+Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor
+angelegt (z. B. `S7 S Strausberg`). Der Sensor zeigt die Zeit der nächsten
 Abfahrt als Zustand an. Weitere Abfahrten werden als Attribut `departures`
-bereitgestellt.
+bereitgestellt. Zusätzlich werden Informationen zur Haltestelle wie
+`latitude` und `longitude` als Attribute bereitgestellt.
 
 ## Hinweise
 
 Die Integration verwendet die öffentliche API unter
 `https://v5.vbb.transport.rest/`. Für die Verwendung ist eine funktionierende
 Internetverbindung erforderlich.
+
+Es werden bis zu 100 Abfahrten abgefragt, um auch große Haltestellen
+vollständig abzudecken.

--- a/custom_components/vbb/const.py
+++ b/custom_components/vbb/const.py
@@ -1,6 +1,6 @@
 """Constants for the VBB departures integration."""
 
 DOMAIN = "vbb"
-API_URL = "https://v5.vbb.transport.rest/stops/{station}/departures?duration=120&results=20"
+API_URL = "https://v5.vbb.transport.rest/stops/{station}/departures?duration=120&results=100"
 CONF_STATION_ID = "station_id"
 DEFAULT_NAME = "VBB Departures"


### PR DESCRIPTION
## Summary
- expand VBB API query to return up to 100 departures per station
- name sensors by their destination and create them per line/direction
- expose stop coordinates and extra departure details as sensor attributes
- document new sensor naming and attributes in the README

## Testing
- `python -m py_compile custom_components/vbb/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf2d3c5083278149546e8cd06cce