### PR TITLE
feat: make API query window configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Nach der Installation kann die Integration über die Benutzeroberfläche
 konfiguriert werden. Gehe zu **Einstellungen → Geräte & Dienste → Integration
 hinzufügen** und wähle **VBB Public Transport** aus. Gib die gewünschte
 Haltestellen-ID (z. B. `900000003201` für Berlin Hauptbahnhof) sowie einen
-Namen an.
+Namen an. Zusätzlich können die Abfragezeitspanne (`duration` in Minuten) und
+die maximale Anzahl an Ergebnissen (`results`) eingestellt werden.
 
 Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor
 angelegt (z. B. `S7 S Strausberg`). Der Sensor zeigt die Zeit der nächsten
@@ -41,8 +42,8 @@ Die Integration verwendet die öffentliche API unter
 `https://v5.vbb.transport.rest/`. Für die Verwendung ist eine funktionierende
 Internetverbindung erforderlich.
 
-Es werden bis zu 100 Abfahrten abgefragt, um auch große Haltestellen
-vollständig abzudecken.
+Standardmäßig werden die Abfahrten für 120 Minuten im Voraus und maximal 100
+Ergebnisse abgefragt. Diese Werte lassen sich in der Konfiguration anpassen.
 
 ## Autor
 

--- a/custom_components/vbb/config_flow.py
+++ b/custom_components/vbb/config_flow.py
@@ -7,12 +7,26 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_STATION_ID, DEFAULT_NAME, DOMAIN
+from .const import (
+    CONF_DURATION,
+    CONF_RESULTS,
+    CONF_STATION_ID,
+    DEFAULT_DURATION,
+    DEFAULT_NAME,
+    DEFAULT_RESULTS,
+    DOMAIN,
+)
 
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_STATION_ID): str,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_DURATION, default=DEFAULT_DURATION): vol.All(
+            int, vol.Range(min=1)
+        ),
+        vol.Optional(CONF_RESULTS, default=DEFAULT_RESULTS): vol.All(
+            int, vol.Range(min=1)
+        ),
     }
 )
 

--- a/custom_components/vbb/const.py
+++ b/custom_components/vbb/const.py
@@ -1,6 +1,13 @@
 """Constants for the VBB departures integration."""
 
 DOMAIN = "vbb"
-API_URL = "https://v5.vbb.transport.rest/stops/{station}/departures?duration=120&results=100"
+API_URL = (
+    "https://v5.vbb.transport.rest/stops/{station}/departures"
+    "?duration={duration}&results={results}"
+)
 CONF_STATION_ID = "station_id"
+CONF_DURATION = "duration"
+CONF_RESULTS = "results"
 DEFAULT_NAME = "VBB Departures"
+DEFAULT_DURATION = 120
+DEFAULT_RESULTS = 100

--- a/custom_components/vbb/manifest.json
+++ b/custom_components/vbb/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "vbb",
   "name": "VBB Public Transport",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "documentation": "https://github.com/username/HA-Public-Transport-VBB",
   "requirements": [],
   "codeowners": ["@nobody"],

--- a/custom_components/vbb/translations/de.json
+++ b/custom_components/vbb/translations/de.json
@@ -6,7 +6,9 @@
         "description": "Richte eine VBB-Haltestelle ein.",
         "data": {
           "station_id": "Haltestellen-ID",
-          "name": "Name"
+          "name": "Name",
+          "duration": "Zeitraum (Minuten)",
+          "results": "Maximale Ergebnisse"
         }
       }
     }

--- a/custom_components/vbb/translations/en.json
+++ b/custom_components/vbb/translations/en.json
@@ -6,7 +6,9 @@
         "description": "Set up a VBB stop.",
         "data": {
           "station_id": "Station ID",
-          "name": "Name"
+          "name": "Name",
+          "duration": "Time span (minutes)",
+          "results": "Maximum results"
         }
       }
     }


### PR DESCRIPTION
## Summary
- allow configuring API request `duration` and `results` parameters
- document duration and result limit options and update translations
- bump integration version to 0.3.0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2e7fadebc8327b4672302c80690e5