### PR TITLE
fix: update transport.rest API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ die maximale Anzahl an Ergebnissen (`results`) eingestellt werden.
 ### Haltestellen-ID finden
 
 Die ID einer Haltestelle lässt sich über die öffentliche API ermitteln. Rufe
-im Browser `https://v6.vbb.transport.rest/locations?query=<Haltestellenname>`
-auf (z. B. `https://v6.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`).
+im Browser `https://v6.transport.rest/vbb/locations?query=<Haltestellenname>`
+auf (z. B. `https://v6.transport.rest/vbb/locations?query=Berlin%20Hauptbahnhof`).
 In der JSON-Antwort steht im Feld `id` die benötigte Haltestellen-ID.
 
 Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor
@@ -48,7 +48,7 @@ als Attribute bereitgestellt.
 ## Hinweise
 
 Die Integration verwendet die öffentliche API unter
-`https://v6.vbb.transport.rest/`. Für die Verwendung ist eine funktionierende
+`https://v6.transport.rest/vbb/`. Für die Verwendung ist eine funktionierende
 Internetverbindung erforderlich.
 
 Standardmäßig werden die Abfahrten für 120 Minuten im Voraus und maximal 100

--- a/custom_components/vbb/const.py
+++ b/custom_components/vbb/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "vbb"
 API_URL = (
-    "https://v6.vbb.transport.rest/stops/{station}/departures"
+    "https://v6.transport.rest/vbb/stops/{station}/departures"
     "?duration={duration}&results={results}"
 )
 HEADERS = {


### PR DESCRIPTION
## Summary
- point integration to new transport.rest API host and path
- update documentation links accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3b6142704832799c9bfb47ae84bf9