### PR TITLE
feat: add station search to config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,20 @@ Alternativ kann der Ordner `custom_components/vbb` manuell in das
 
 Nach der Installation kann die Integration über die Benutzeroberfläche
 konfiguriert werden. Gehe zu **Einstellungen → Geräte & Dienste → Integration
-hinzufügen** und wähle **VBB Public Transport** aus. Gib die gewünschte
-Haltestellen-ID (z. B. `900000003201` für Berlin Hauptbahnhof) sowie einen
-Namen an. Zusätzlich können die Abfragezeitspanne (`duration` in Minuten) und
-die maximale Anzahl an Ergebnissen (`results`) eingestellt werden.
+hinzufügen** und wähle **VBB Public Transport** aus. Suche nach einer
+Haltestelle, indem du den Namen oder Koordinaten eingibst, und wähle den
+gewünschten Treffer aus. Anschließend können Name, Abfragezeitspanne
+(`duration` in Minuten) und die maximale Anzahl an Ergebnissen (`results`)
+festgelegt werden.
 
 ### Haltestellen-ID finden
 
-Die ID einer Haltestelle lässt sich über die öffentliche API ermitteln. Rufe
-im Browser `https://v5.vbb.transport.rest/locations?query=<Haltestellenname>`
-auf (z. B. `https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`).
-In der JSON-Antwort steht im Feld `id` die benötigte Haltestellen-ID.
+Die ID einer Haltestelle lässt sich weiterhin über die öffentliche API
+ermitteln. Rufe im Browser
+`https://v5.vbb.transport.rest/locations?query=<Haltestellenname>` auf (z. B.
+`https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). In der
+JSON-Antwort steht im Feld `id` die Haltestellen-ID, die von der Integration
+verwendet wird.
 
 Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor
 angelegt (z. B. `S7 S Strausberg`). Der Sensor zeigt die Zeit der nächsten

--- a/custom_components/vbb/config_flow.py
+++ b/custom_components/vbb/config_flow.py
@@ -1,11 +1,19 @@
-"""Config flow for VBB integration."""
+"""Config flow for VBB integration with station search."""
 
 from __future__ import annotations
 
+from typing import Any, Dict, List
+
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 
 from .const import (
     CONF_DURATION,
@@ -15,19 +23,9 @@ from .const import (
     DEFAULT_NAME,
     DEFAULT_RESULTS,
     DOMAIN,
-)
-
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_STATION_ID): str,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_DURATION, default=DEFAULT_DURATION): vol.All(
-            int, vol.Range(min=1)
-        ),
-        vol.Optional(CONF_RESULTS, default=DEFAULT_RESULTS): vol.All(
-            int, vol.Range(min=1)
-        ),
-    }
+    HEADERS,
+    NEARBY_URL,
+    SEARCH_URL,
 )
 
 
@@ -36,10 +34,121 @@ class VbbConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_STATION_ID])
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+    def __init__(self) -> None:
+        self._stations: List[Dict[str, Any]] = []
+        self._selected_station: Dict[str, Any] | None = None
 
-        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+    async def async_step_user(self, user_input: Dict[str, Any] | None = None):
+        """Handle the initial step where the user searches for a station."""
+
+        errors: Dict[str, str] = {}
+
+        if user_input is not None:
+            station_name = user_input.get("station_name")
+            latitude = user_input.get(CONF_LATITUDE)
+            longitude = user_input.get(CONF_LONGITUDE)
+
+            if station_name:
+                self._stations = await self._search_by_name(station_name)
+            elif latitude is not None and longitude is not None:
+                self._stations = await self._search_by_coordinates(latitude, longitude)
+            else:
+                errors["base"] = "no_input"
+
+            if not errors and not self._stations:
+                errors["base"] = "no_stations"
+
+            if not errors:
+                return await self.async_step_select_station()
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional("station_name"): cv.string,
+                vol.Optional(CONF_LATITUDE): vol.Coerce(float),
+                vol.Optional(CONF_LONGITUDE): vol.Coerce(float),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_select_station(
+        self, user_input: Dict[str, Any] | None = None
+    ):
+        """Let the user select one of the found stations."""
+
+        if user_input is not None:
+            station_id = user_input[CONF_STATION_ID]
+            self._selected_station = next(
+                s for s in self._stations if s["id"] == station_id
+            )
+            return await self.async_step_config()
+
+        options = [
+            {"label": f"{s['name']} ({s['id']})", "value": s["id"]}
+            for s in self._stations
+        ]
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_STATION_ID): SelectSelector(
+                    SelectSelectorConfig(options=options)
+                )
+            }
+        )
+
+        return self.async_show_form(step_id="select_station", data_schema=data_schema)
+
+    async def async_step_config(self, user_input: Dict[str, Any] | None = None):
+        """Configure additional options and create the entry."""
+
+        assert self._selected_station is not None
+
+        if user_input is not None:
+            data = {
+                CONF_STATION_ID: self._selected_station["id"],
+                CONF_NAME: user_input[CONF_NAME],
+                CONF_DURATION: user_input[CONF_DURATION],
+                CONF_RESULTS: user_input[CONF_RESULTS],
+            }
+            await self.async_set_unique_id(self._selected_station["id"])
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=data[CONF_NAME], data=data)
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_NAME, default=self._selected_station["name"] or DEFAULT_NAME
+                ): cv.string,
+                vol.Optional(
+                    CONF_DURATION, default=DEFAULT_DURATION
+                ): vol.All(int, vol.Range(min=1)),
+                vol.Optional(
+                    CONF_RESULTS, default=DEFAULT_RESULTS
+                ): vol.All(int, vol.Range(min=1)),
+            }
+        )
+
+        return self.async_show_form(step_id="config", data_schema=data_schema)
+
+    async def _search_by_name(self, name: str) -> List[Dict[str, Any]]:
+        """Search stations by name using the VBB API."""
+        session = async_get_clientsession(self.hass)
+        params = {"query": name}
+        async with session.get(SEARCH_URL, params=params, headers=HEADERS) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+        return [s for s in data if s.get("id") and s.get("name")]
+
+    async def _search_by_coordinates(
+        self, latitude: float, longitude: float
+    ) -> List[Dict[str, Any]]:
+        """Search stations near the given coordinates."""
+        session = async_get_clientsession(self.hass)
+        params = {"latitude": latitude, "longitude": longitude}
+        async with session.get(NEARBY_URL, params=params, headers=HEADERS) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+        return [s for s in data if s.get("id") and s.get("name")]
+

--- a/custom_components/vbb/const.py
+++ b/custom_components/vbb/const.py
@@ -5,6 +5,8 @@ API_URL = (
     "https://v5.vbb.transport.rest/stops/{station}/departures"
     "?duration={duration}&results={results}"
 )
+SEARCH_URL = "https://v5.vbb.transport.rest/locations"
+NEARBY_URL = "https://v5.vbb.transport.rest/locations/nearby"
 HEADERS = {
     "Accept": "application/json",
     "User-Agent": "HomeAssistant-VBB",

--- a/custom_components/vbb/translations/de.json
+++ b/custom_components/vbb/translations/de.json
@@ -3,14 +3,31 @@
     "step": {
       "user": {
         "title": "VBB Öffentlicher Nahverkehr",
-        "description": "Richte eine VBB-Haltestelle ein.",
+        "description": "Suche eine Haltestelle per Name oder Koordinaten.",
         "data": {
-          "station_id": "Haltestellen-ID",
+          "station_name": "Haltestellenname",
+          "latitude": "Breitengrad",
+          "longitude": "Längengrad"
+        }
+      },
+      "select_station": {
+        "title": "Haltestelle auswählen",
+        "data": {
+          "station_id": "Haltestelle"
+        }
+      },
+      "config": {
+        "title": "VBB Öffentlicher Nahverkehr",
+        "data": {
           "name": "Name",
           "duration": "Zeitraum (Minuten)",
           "results": "Maximale Ergebnisse"
         }
       }
+    },
+    "error": {
+      "no_input": "Bitte Stationsnamen oder Koordinaten angeben.",
+      "no_stations": "Keine Haltestellen gefunden."
     }
   }
 }

--- a/custom_components/vbb/translations/en.json
+++ b/custom_components/vbb/translations/en.json
@@ -3,14 +3,31 @@
     "step": {
       "user": {
         "title": "VBB Public Transport",
-        "description": "Set up a VBB stop.",
+        "description": "Search for a station by name or coordinates.",
         "data": {
-          "station_id": "Station ID",
+          "station_name": "Station name",
+          "latitude": "Latitude",
+          "longitude": "Longitude"
+        }
+      },
+      "select_station": {
+        "title": "Select station",
+        "data": {
+          "station_id": "Station"
+        }
+      },
+      "config": {
+        "title": "VBB Public Transport",
+        "data": {
           "name": "Name",
           "duration": "Time span (minutes)",
           "results": "Maximum results"
         }
       }
+    },
+    "error": {
+      "no_input": "Provide a station name or coordinates.",
+      "no_stations": "No stations found."
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow searching VBB stations by name or coordinates during config
- document new station search workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3e9be6ea083278c2d6a60ce3aa9e1