### PR TITLE
docs: add multilingual setup guides

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,42 @@
+# HA Public Transport VBB
+
+Dieses Repository stellt eine Home-Assistant Integration bereit, um Abfahrtszeiten des Verkehrsverbunds Berlin-Brandenburg (VBB) als Sensoren anzuzeigen. Jede konfigurierte Haltestelle erscheint in Home Assistant als eigenes Gerät.
+
+## Beispiel
+
+![Beispielbild Berlin Hauptbahnhof](images/Hauptbahnhof.png)
+
+## Installation
+
+Die Integration kann über [HACS](https://hacs.xyz/) installiert werden:
+
+1. Füge dieses Repository in HACS als benutzerdefiniertes Repository hinzu.
+2. Suche nach "VBB Public Transport" und installiere die Integration.
+3. Starte Home Assistant neu.
+
+Alternativ kann der Ordner `custom_components/vbb` manuell in das `custom_components` Verzeichnis kopiert werden.
+
+## Konfiguration
+
+Nach der Installation kann die Integration über die Benutzeroberfläche konfiguriert werden:
+
+1. Gehe zu **Einstellungen → Geräte & Dienste → Integration hinzufügen**.
+2. Wähle **VBB Public Transport** aus.
+3. Suche nach einer Haltestelle, indem du den Namen oder Koordinaten eingibst, und wähle den gewünschten Treffer aus.
+4. Lege Name, Abfragezeitspanne (`duration` in Minuten) und die maximale Anzahl an Ergebnissen (`results`) fest.
+
+### Haltestellen-ID (optional)
+
+Die Integration enthält eine Suchfunktion, sodass keine manuelle Haltestellen-ID benötigt wird. Die ID lässt sich weiterhin über die öffentliche API ermitteln: `https://v5.vbb.transport.rest/locations?query=<Haltestellenname>` (z. B. `https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). In der JSON-Antwort steht im Feld `id` die Haltestellen-ID.
+
+Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor angelegt (z. B. `S7 S Strausberg`). Der Sensor zeigt die Zeit der nächsten Abfahrt als Zustand an. Die aktuelle Verspätung in Minuten wird als Attribut `delay` angezeigt. Weitere Abfahrten stehen als Attribut `departures` zur Verfügung. Zusätzlich werden Informationen wie `latitude`, `longitude`, `station_dhid`, `line_id`, `operator` und `trip_id` bereitgestellt.
+
+## Hinweise
+
+Die Integration verwendet die öffentliche API unter `https://v5.vbb.transport.rest/`. Eine funktionierende Internetverbindung ist erforderlich.
+
+Standardmäßig werden Abfahrten für 120 Minuten im Voraus und maximal 100 Ergebnisse abgefragt. Diese Werte lassen sich in der Konfiguration anpassen.
+
+## Autor
+
+Dieses Repository wurde von [404GamerNotFound](https://github.com/404GamerNotFound) (Tony Brüser) erstellt.

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,42 @@
+# HA Public Transport VBB
+
+This repository provides a Home Assistant integration that fetches departure times from the Berlin–Brandenburg public transport network (VBB) and exposes them as sensors. Each configured stop appears in Home Assistant as its own device.
+
+## Example
+
+![Example image Berlin Hauptbahnhof](images/Hauptbahnhof.png)
+
+## Installation
+
+The integration can be installed through [HACS](https://hacs.xyz/):
+
+1. Add this repository to HACS as a custom repository.
+2. Search for "VBB Public Transport" and install the integration.
+3. Restart Home Assistant.
+
+Alternatively, copy the `custom_components/vbb` folder into your `custom_components` directory.
+
+## Configuration
+
+After installation the integration can be configured via the user interface:
+
+1. Go to **Settings → Devices & Services → Add Integration**.
+2. Choose **VBB Public Transport**.
+3. Search for a stop by entering its name or coordinates and select the desired result.
+4. Set the name, query window (`duration` in minutes) and the maximum number of results (`results`).
+
+### Stop ID (optional)
+
+The integration includes a search function so a manual stop ID is no longer required. It can still be retrieved from the public API: `https://v5.vbb.transport.rest/locations?query=<stop name>` (e.g. `https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). The stop ID is located in the `id` field of the JSON response.
+
+For each line and direction at the stop a separate sensor is created (e.g. `S7 S Strausberg`). The sensor's state shows the next departure time. The current delay in minutes is exposed as the `delay` attribute. Further departures are available in the `departures` attribute. Additional information such as `latitude`, `longitude`, `station_dhid`, `line_id`, `operator` and `trip_id` is provided.
+
+## Notes
+
+The integration uses the public API at `https://v5.vbb.transport.rest/`. An active internet connection is required.
+
+By default departures for 120 minutes ahead and up to 100 results are queried. These values can be adjusted in the configuration.
+
+## Author
+
+This repository was created by [404GamerNotFound](https://github.com/404GamerNotFound) (Tony Brüser).

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,42 @@
+# HA Public Transport VBB
+
+Este repositorio ofrece una integración para Home Assistant que obtiene los horarios de salida de la red de transporte público de Berlín-Brandeburgo (VBB) y los expone como sensores. Cada parada configurada aparece en Home Assistant como un dispositivo propio.
+
+## Ejemplo
+
+![Imagen de ejemplo Berlin Hauptbahnhof](images/Hauptbahnhof.png)
+
+## Instalación
+
+La integración puede instalarse a través de [HACS](https://hacs.xyz/):
+
+1. Añade este repositorio como repositorio personalizado en HACS.
+2. Busca "VBB Public Transport" e instala la integración.
+3. Reinicia Home Assistant.
+
+Como alternativa, copia la carpeta `custom_components/vbb` en tu directorio `custom_components`.
+
+## Configuración
+
+Después de la instalación, la integración puede configurarse mediante la interfaz de usuario:
+
+1. Ve a **Ajustes → Dispositivos y servicios → Añadir integración**.
+2. Elige **VBB Public Transport**.
+3. Busca una parada introduciendo su nombre o coordenadas y selecciona el resultado deseado.
+4. Define el nombre, el intervalo de consulta (`duration` en minutos) y el número máximo de resultados (`results`).
+
+### ID de parada (opcional)
+
+La integración incluye una función de búsqueda, por lo que ya no es necesario proporcionar manualmente la ID de la parada. Aun así puede obtenerse mediante la API pública: `https://v5.vbb.transport.rest/locations?query=<nombre de la parada>` (ej. `https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). La ID se encuentra en el campo `id` de la respuesta JSON.
+
+Para cada línea y dirección en la parada se crea un sensor separado (p. ej. `S7 S Strausberg`). El estado del sensor muestra la hora de la siguiente salida. El retraso actual en minutos se expone en el atributo `delay`. Otras salidas están disponibles en el atributo `departures`. Se proporciona información adicional como `latitude`, `longitude`, `station_dhid`, `line_id`, `operator` y `trip_id`.
+
+## Notas
+
+La integración utiliza la API pública `https://v5.vbb.transport.rest/`. Se requiere una conexión a Internet activa.
+
+Por defecto se consultan las salidas para los próximos 120 minutos y hasta 100 resultados. Estos valores pueden ajustarse en la configuración.
+
+## Autor
+
+Este repositorio fue creado por [404GamerNotFound](https://github.com/404GamerNotFound) (Tony Brüser).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,42 @@
+# HA Public Transport VBB
+
+Ce dépôt fournit une intégration Home Assistant permettant d'obtenir les horaires de départ du réseau de transport public de Berlin-Brandebourg (VBB) et de les exposer sous forme de capteurs. Chaque arrêt configuré apparaît dans Home Assistant comme un appareil distinct.
+
+## Exemple
+
+![Exemple image Berlin Hauptbahnhof](images/Hauptbahnhof.png)
+
+## Installation
+
+L'intégration peut être installée via [HACS](https://hacs.xyz/) :
+
+1. Ajoutez ce dépôt comme dépôt personnalisé dans HACS.
+2. Recherchez « VBB Public Transport » et installez l'intégration.
+3. Redémarrez Home Assistant.
+
+Sinon, copiez le dossier `custom_components/vbb` dans votre répertoire `custom_components`.
+
+## Configuration
+
+Après l'installation l'intégration peut être configurée via l'interface utilisateur :
+
+1. Allez dans **Paramètres → Appareils et services → Ajouter une intégration**.
+2. Choisissez **VBB Public Transport**.
+3. Recherchez un arrêt en saisissant son nom ou ses coordonnées et sélectionnez le résultat souhaité.
+4. Définissez le nom, la période de requête (`duration` en minutes) et le nombre maximal de résultats (`results`).
+
+### ID d'arrêt (optionnel)
+
+L'intégration inclut une fonction de recherche, il n'est donc plus nécessaire de saisir manuellement l'ID d'arrêt. Il est toujours possible de l'obtenir via l'API publique : `https://v5.vbb.transport.rest/locations?query=<nom de l'arrêt>` (ex. `https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). L'ID d'arrêt se trouve dans le champ `id` de la réponse JSON.
+
+Pour chaque ligne et direction à l'arrêt un capteur séparé est créé (par ex. `S7 S Strausberg`). L'état du capteur indique le prochain départ. Le retard actuel en minutes est exposé dans l'attribut `delay`. Les autres départs sont disponibles dans l'attribut `departures`. Des informations supplémentaires comme `latitude`, `longitude`, `station_dhid`, `line_id`, `operator` et `trip_id` sont fournies.
+
+## Remarques
+
+L'intégration utilise l'API publique `https://v5.vbb.transport.rest/`. Une connexion Internet active est nécessaire.
+
+Par défaut les départs des 120 prochaines minutes et jusqu'à 100 résultats sont interrogés. Ces valeurs peuvent être ajustées dans la configuration.
+
+## Auteur
+
+Ce dépôt a été créé par [404GamerNotFound](https://github.com/404GamerNotFound) (Tony Brüser).

--- a/README.md
+++ b/README.md
@@ -1,62 +1,11 @@
 # HA Public Transport VBB
 
-Dieses Repository stellt ein einfaches Home-Assistant Plugin bereit, um
-Abfahrtszeiten des Verkehrsverbunds Berlin-Brandenburg (VBB) abzurufen und
-als Sensor anzuzeigen. Jede konfigurierte Haltestelle wird in Home Assistant
-als eigenes Gerät dargestellt.
+Home Assistant integration for public transport departures in Berlin-Brandenburg (VBB).
 
-## Beispiel
+## Languages
 
-![Beispielbild Berlin Hauptbahnhof](images/Hauptbahnhof.png)
-
-## Installation
-
-Die Integration kann bequem über [HACS](https://hacs.xyz/) installiert
-werden:
-
-1. Füge dieses Repository in HACS als benutzerdefiniertes Repository hinzu.
-2. Suche nach "VBB Public Transport" und installiere die Integration.
-3. Starte Home Assistant neu.
-
-Alternativ kann der Ordner `custom_components/vbb` manuell in das
-`custom_components` Verzeichnis kopiert werden.
-
-## Konfiguration
-
-Nach der Installation kann die Integration über die Benutzeroberfläche
-konfiguriert werden. Gehe zu **Einstellungen → Geräte & Dienste → Integration
-hinzufügen** und wähle **VBB Public Transport** aus. Suche nach einer
-Haltestelle, indem du den Namen oder Koordinaten eingibst, und wähle den
-gewünschten Treffer aus. Anschließend können Name, Abfragezeitspanne
-(`duration` in Minuten) und die maximale Anzahl an Ergebnissen (`results`)
-festgelegt werden.
-
-### Haltestellen-ID finden
-
-Die ID einer Haltestelle lässt sich weiterhin über die öffentliche API
-ermitteln. Rufe im Browser
-`https://v5.vbb.transport.rest/locations?query=<Haltestellenname>` auf (z. B.
-`https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). In der
-JSON-Antwort steht im Feld `id` die Haltestellen-ID, die von der Integration
-verwendet wird.
-
-Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor
-angelegt (z. B. `S7 S Strausberg`). Der Sensor zeigt die Zeit der nächsten
-Abfahrt als Zustand an. Die aktuelle Verspätung in Minuten wird als Attribut
-`delay` angezeigt. Weitere Abfahrten werden als Attribut `departures`
-bereitgestellt. Zusätzlich werden Informationen zur Haltestelle wie
-`latitude`, `longitude`, `station_dhid`, `line_id`, `operator` und `trip_id`
-als Attribute bereitgestellt.
-
-## Hinweise
-
-Die Integration verwendet die öffentliche API unter
-`https://v5.vbb.transport.rest/`. Für die Verwendung ist eine funktionierende
-Internetverbindung erforderlich.
-
-Standardmäßig werden die Abfahrten für 120 Minuten im Voraus und maximal 100
-Ergebnisse abgefragt. Diese Werte lassen sich in der Konfiguration anpassen.
-
-## Autor
-
-Dieses Repository wurde von [404GamerNotFound](https://github.com/404GamerNotFound) (Tony Brüser) erstellt.
+- [Deutsch](README.de.md)
+- [English](README.en.md)
+- [Français](README.fr.md)
+- [Español](README.es.md)
+- [Polski](README.pl.md)

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,42 @@
+# HA Public Transport VBB
+
+To repozytorium udostępnia integrację Home Assistant, która pobiera czasy odjazdów z sieci transportu publicznego Berlina i Brandenburgii (VBB) i prezentuje je jako sensory. Każdy skonfigurowany przystanek pojawia się w Home Assistant jako osobne urządzenie.
+
+## Przykład
+
+![Przykładowy obraz Berlin Hauptbahnhof](images/Hauptbahnhof.png)
+
+## Instalacja
+
+Integrację można zainstalować przez [HACS](https://hacs.xyz/):
+
+1. Dodaj to repozytorium jako repozytorium niestandardowe w HACS.
+2. Wyszukaj "VBB Public Transport" i zainstaluj integrację.
+3. Uruchom ponownie Home Assistant.
+
+Alternatywnie skopiuj folder `custom_components/vbb` do swojego katalogu `custom_components`.
+
+## Konfiguracja
+
+Po instalacji integrację można skonfigurować za pomocą interfejsu użytkownika:
+
+1. Przejdź do **Ustawienia → Urządzenia i usługi → Dodaj integrację**.
+2. Wybierz **VBB Public Transport**.
+3. Wyszukaj przystanek, wpisując jego nazwę lub współrzędne, i wybierz odpowiedni wynik.
+4. Ustaw nazwę, okno zapytania (`duration` w minutach) oraz maksymalną liczbę wyników (`results`).
+
+### ID przystanku (opcjonalnie)
+
+Integracja zawiera funkcję wyszukiwania, więc ręczne podawanie ID przystanku nie jest już wymagane. Nadal można je uzyskać z publicznego API: `https://v5.vbb.transport.rest/locations?query=<nazwa przystanku>` (np. `https://v5.vbb.transport.rest/locations?query=Berlin%20Hauptbahnhof`). ID przystanku znajduje się w polu `id` odpowiedzi JSON.
+
+Dla każdej linii i kierunku na przystanku tworzony jest osobny sensor (np. `S7 S Strausberg`). Stan sensora pokazuje czas następnego odjazdu. Aktualne opóźnienie w minutach udostępniane jest w atrybucie `delay`. Kolejne odjazdy są dostępne w atrybucie `departures`. Udostępniane są również dodatkowe informacje jak `latitude`, `longitude`, `station_dhid`, `line_id`, `operator` i `trip_id`.
+
+## Uwagi
+
+Integracja korzysta z publicznego API `https://v5.vbb.transport.rest/`. Wymagane jest aktywne połączenie z Internetem.
+
+Domyślnie pobierane są odjazdy na 120 minut do przodu i maksymalnie 100 wyników. Wartości te można dostosować w konfiguracji.
+
+## Autor
+
+Repozytorium zostało stworzone przez [404GamerNotFound](https://github.com/404GamerNotFound) (Tony Brüser).


### PR DESCRIPTION
## Summary
- replace main README with language index
- add detailed setup guides in German, English, French, Spanish and Polish

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c50351ebe483278561e72696875a41