### PR TITLE
Add transport product switches and direction aggregation

### DIFF
--- a/custom_components/vbb/__init__.py
+++ b/custom_components/vbb/__init__.py
@@ -7,12 +7,12 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "switch"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up VBB from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
+    hass.data[DOMAIN][entry.entry_id] = entry
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/vbb/config_flow.py
+++ b/custom_components/vbb/config_flow.py
@@ -17,11 +17,14 @@ from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 
 from .const import (
     CONF_DURATION,
+    CONF_PRODUCTS,
     CONF_RESULTS,
     CONF_STATION_ID,
+    DEFAULT_PRODUCTS,
     DEFAULT_DURATION,
     DEFAULT_NAME,
     DEFAULT_RESULTS,
+    PRODUCT_OPTIONS,
     DOMAIN,
     HEADERS,
     NEARBY_URL,
@@ -112,9 +115,12 @@ class VbbConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_DURATION: user_input[CONF_DURATION],
                 CONF_RESULTS: user_input[CONF_RESULTS],
             }
+            options = {CONF_PRODUCTS: user_input.get(CONF_PRODUCTS, DEFAULT_PRODUCTS)}
             await self.async_set_unique_id(self._selected_station["id"])
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=data[CONF_NAME], data=data)
+            return self.async_create_entry(
+                title=data[CONF_NAME], data=data, options=options
+            )
 
         data_schema = vol.Schema(
             {
@@ -127,6 +133,17 @@ class VbbConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_RESULTS, default=DEFAULT_RESULTS
                 ): vol.All(int, vol.Range(min=1)),
+                vol.Optional(
+                    CONF_PRODUCTS, default=DEFAULT_PRODUCTS
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            {"label": p.title(), "value": p}
+                            for p in PRODUCT_OPTIONS
+                        ],
+                        multiple=True,
+                    )
+                ),
             }
         )
 

--- a/custom_components/vbb/const.py
+++ b/custom_components/vbb/const.py
@@ -14,6 +14,17 @@ HEADERS = {
 CONF_STATION_ID = "station_id"
 CONF_DURATION = "duration"
 CONF_RESULTS = "results"
+CONF_PRODUCTS = "products"
 DEFAULT_NAME = "VBB Departures"
 DEFAULT_DURATION = 120
 DEFAULT_RESULTS = 100
+PRODUCT_OPTIONS = [
+    "suburban",
+    "subway",
+    "tram",
+    "bus",
+    "ferry",
+    "regional",
+    "express",
+]
+DEFAULT_PRODUCTS = PRODUCT_OPTIONS

--- a/custom_components/vbb/manifest.json
+++ b/custom_components/vbb/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "vbb",
   "name": "VBB Public Transport",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "documentation": "https://github.com/username/HA-Public-Transport-VBB",
   "requirements": [],
   "codeowners": ["@nobody"],

--- a/custom_components/vbb/sensor.py
+++ b/custom_components/vbb/sensor.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Any
-from collections import defaultdict
 
 import async_timeout
 import voluptuous as vol
@@ -18,17 +17,21 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import slugify
 
 from .const import (
     API_URL,
     CONF_DURATION,
+    CONF_PRODUCTS,
     CONF_RESULTS,
     CONF_STATION_ID,
     DEFAULT_DURATION,
+    DEFAULT_PRODUCTS,
     DEFAULT_NAME,
     DEFAULT_RESULTS,
     DOMAIN,
+    PRODUCT_OPTIONS,
     HEADERS,
 )
 
@@ -42,6 +45,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_RESULTS, default=DEFAULT_RESULTS): vol.All(
             int, vol.Range(min=1)
         ),
+        vol.Optional(
+            CONF_PRODUCTS, default=DEFAULT_PRODUCTS
+        ): vol.All(cv.ensure_list, [vol.In(PRODUCT_OPTIONS)]),
     }
 )
 
@@ -70,31 +76,71 @@ def _get_delay(entry: dict[str, Any]) -> int | None:
     return delay
 
 
+async def _async_setup_station(
+    hass,
+    station_id: str,
+    name: str,
+    duration: int,
+    results: int,
+    products: list[str],
+    async_add_entities,
+) -> None:
+    """Set up sensors for a station and add new ones dynamically."""
+    session = async_get_clientsession(hass)
+    known_pairs: set[tuple[str, str]] = set()
+    known_dirs: set[tuple[str, str]] = set()
+
+    async def discover(now=None):
+        url = API_URL.format(station=station_id, duration=duration, results=results)
+        try:
+            async with async_timeout.timeout(10):
+                resp = await session.get(url, headers=HEADERS)
+                resp.raise_for_status()
+                data = await resp.json()
+        except Exception:
+            return
+
+        sensors: list[SensorEntity] = []
+        for d in data:
+            line_info = d.get("line") or {}
+            if line_info.get("product") not in products:
+                continue
+            line = line_info.get("name")
+            dest_info = d.get("destination") or {}
+            destination = dest_info.get("name") or d.get("direction")
+            direction = d.get("direction")
+            if line and destination and (line, destination) not in known_pairs:
+                known_pairs.add((line, destination))
+                sensors.append(
+                    VbbDepartureSensor(
+                        hass, station_id, name, line, destination, duration, results
+                    )
+                )
+            if line and direction and (line, direction) not in known_dirs:
+                known_dirs.add((line, direction))
+                sensors.append(
+                    VbbDirectionSensor(
+                        hass, station_id, name, line, direction, duration, results
+                    )
+                )
+
+        if sensors:
+            async_add_entities(sensors, True)
+
+    await discover()
+    async_track_time_interval(hass, discover, timedelta(minutes=5))
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the VBB sensor platform."""
     station_id = config[CONF_STATION_ID]
     name = config[CONF_NAME]
     duration = config.get(CONF_DURATION, DEFAULT_DURATION)
     results = config.get(CONF_RESULTS, DEFAULT_RESULTS)
-    session = async_get_clientsession(hass)
-    url = API_URL.format(station=station_id, duration=duration, results=results)
-    async with async_timeout.timeout(10):
-        resp = await session.get(url, headers=HEADERS)
-        resp.raise_for_status()
-        data = await resp.json()
-    lines: dict[str, set[str]] = defaultdict(set)
-    for d in data:
-        line = (d.get("line") or {}).get("name")
-        dest_info = d.get("destination") or {}
-        destination = dest_info.get("name") or d.get("direction")
-        if line and destination:
-            lines[line].add(destination)
-    sensors = [
-        VbbDepartureSensor(hass, station_id, name, line, dest, duration, results)
-        for line, destinations in lines.items()
-        for dest in destinations
-    ]
-    async_add_entities(sensors, True)
+    products = config.get(CONF_PRODUCTS, DEFAULT_PRODUCTS)
+    await _async_setup_station(
+        hass, station_id, name, duration, results, products, async_add_entities
+    )
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -103,25 +149,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     name = entry.data[CONF_NAME]
     duration = entry.data.get(CONF_DURATION, DEFAULT_DURATION)
     results = entry.data.get(CONF_RESULTS, DEFAULT_RESULTS)
-    session = async_get_clientsession(hass)
-    url = API_URL.format(station=station_id, duration=duration, results=results)
-    async with async_timeout.timeout(10):
-        resp = await session.get(url, headers=HEADERS)
-        resp.raise_for_status()
-        data = await resp.json()
-    lines: dict[str, set[str]] = defaultdict(set)
-    for d in data:
-        line = (d.get("line") or {}).get("name")
-        dest_info = d.get("destination") or {}
-        destination = dest_info.get("name") or d.get("direction")
-        if line and destination:
-            lines[line].add(destination)
-    sensors = [
-        VbbDepartureSensor(hass, station_id, name, line, dest, duration, results)
-        for line, destinations in lines.items()
-        for dest in destinations
-    ]
-    async_add_entities(sensors, True)
+    products = entry.options.get(
+        CONF_PRODUCTS, entry.data.get(CONF_PRODUCTS, DEFAULT_PRODUCTS)
+    )
+    await _async_setup_station(
+        hass, station_id, name, duration, results, products, async_add_entities
+    )
 
 
 class VbbDepartureSensor(SensorEntity):
@@ -229,6 +262,135 @@ class VbbDepartureSensor(SensorEntity):
             "line": self._line,
             "destination": destination_name,
             "direction": self._direction,
+            "station_id": self._station_id,
+            "station_name": stop.get("name"),
+            "station_dhid": stop.get("stationDHID"),
+            "latitude": location.get("latitude"),
+            "longitude": location.get("longitude"),
+            "line_id": line_info.get("id"),
+            "mode": line_info.get("mode"),
+            "product": line_info.get("product"),
+            "operator": line_info.get("operator", {}).get("name"),
+            "trip_id": first.get("tripId"),
+            "delay": delay,
+            "prognosis_type": first.get("prognosisType"),
+            "origin": origin_info.get("name"),
+            "current_trip_position": current_pos or None,
+            "departures": [
+                {
+                    "when": _get_time(d),
+                    "delay": _get_delay(d),
+                    "platform": d.get("platform"),
+                    "destination": (d.get("destination") or {}).get("name"),
+                    "trip_id": d.get("tripId"),
+                    "prognosis_type": d.get("prognosisType"),
+                }
+                for d in departures
+            ],
+        }
+
+
+class VbbDirectionSensor(SensorEntity):
+    """Representation of a VBB direction sensor aggregating all destinations."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:train"
+
+    def __init__(
+        self,
+        hass,
+        station_id: str,
+        station_name: str,
+        line: str,
+        direction: str,
+        duration: int,
+        results: int,
+    ) -> None:
+        self.hass = hass
+        self._station_id = station_id
+        self._station_name = station_name
+        self._line = line
+        self._direction = direction
+        self._duration = duration
+        self._results = results
+        self._attr_name = f"{line} {direction}"
+        self._attr_unique_id = (
+            f"vbb_{station_id}_{slugify(line)}_{slugify(direction)}_dir"
+        )
+        self._attr_extra_state_attributes: dict[str, Any] = {}
+        self._session = async_get_clientsession(hass)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._station_id)},
+            name=self._station_name,
+            manufacturer="VBB",
+        )
+
+    async def async_update(self) -> None:
+        """Fetch departures from the VBB API."""
+        url = API_URL.format(
+            station=self._station_id, duration=self._duration, results=self._results
+        )
+        try:
+            async with async_timeout.timeout(10):
+                resp = await self._session.get(url, headers=HEADERS)
+                resp.raise_for_status()
+                data = await resp.json()
+        except Exception:
+            self._attr_available = False
+            return
+
+        self._attr_available = True
+
+        departures: list[dict[str, Any]] = []
+        for d in data:
+            if d.get("line", {}).get("name") != self._line:
+                continue
+            if d.get("direction") != self._direction:
+                continue
+            when = _get_time(d)
+            if not when:
+                continue
+            try:
+                dep_time = datetime.fromisoformat(when)
+            except ValueError:
+                continue
+            if dep_time <= datetime.now(dep_time.tzinfo or timezone.utc):
+                continue
+            departures.append(d)
+
+        if not departures:
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        departures.sort(key=_get_time)
+        first = departures[0]
+        self._station_name = first.get("stop", {}).get("name", self._station_name)
+        dest_info = first.get("destination") or {}
+        destination_name = dest_info.get("name")
+        when = _get_time(first)
+        if when:
+            try:
+                self._attr_native_value = datetime.fromisoformat(when)
+            except ValueError:
+                self._attr_native_value = when
+        else:
+            self._attr_native_value = None
+
+        stop = first.get("stop") or {}
+        location = stop.get("location") or {}
+        line_info = first.get("line") or {}
+        origin_info = first.get("origin") or {}
+        current_pos = first.get("currentTripPosition") or None
+        delay = _get_delay(first)
+
+        self._attr_extra_state_attributes = {
+            "line": self._line,
+            "direction": self._direction,
+            "destination": destination_name,
             "station_id": self._station_id,
             "station_name": stop.get("name"),
             "station_dhid": stop.get("stationDHID"),

--- a/custom_components/vbb/switch.py
+++ b/custom_components/vbb/switch.py
@@ -1,0 +1,64 @@
+"""Switch entities for toggling VBB transport products."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+
+from .const import CONF_PRODUCTS, PRODUCT_OPTIONS
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up VBB product switches from a config entry."""
+    switches = [
+        VbbProductSwitch(entry, product) for product in PRODUCT_OPTIONS
+    ]
+    async_add_entities(switches)
+
+
+class VbbProductSwitch(SwitchEntity):
+    """Switch to enable or disable a transport product."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, entry: ConfigEntry, product: str) -> None:
+        self._entry = entry
+        self._product = product
+        self._attr_name = product.title()
+        self._attr_unique_id = f"{entry.entry_id}_{product}_enabled"
+
+    @property
+    def is_on(self) -> bool:
+        products: list[str] = self._entry.options.get(
+            CONF_PRODUCTS, self._entry.data.get(CONF_PRODUCTS, PRODUCT_OPTIONS)
+        )
+        return self._product in products
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        products = set(
+            self._entry.options.get(
+                CONF_PRODUCTS, self._entry.data.get(CONF_PRODUCTS, PRODUCT_OPTIONS)
+            )
+        )
+        products.add(self._product)
+        await self._update_products(list(products))
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        products = set(
+            self._entry.options.get(
+                CONF_PRODUCTS, self._entry.data.get(CONF_PRODUCTS, PRODUCT_OPTIONS)
+            )
+        )
+        products.discard(self._product)
+        await self._update_products(list(products))
+
+    async def _update_products(self, products: list[str]) -> None:
+        options = dict(self._entry.options)
+        options[CONF_PRODUCTS] = products
+        self.hass.config_entries.async_update_entry(self._entry, options=options)
+        await self.hass.config_entries.async_reload(self._entry.entry_id)

--- a/custom_components/vbb/translations/de.json
+++ b/custom_components/vbb/translations/de.json
@@ -21,7 +21,8 @@
         "data": {
           "name": "Name",
           "duration": "Zeitraum (Minuten)",
-          "results": "Maximale Ergebnisse"
+          "results": "Maximale Ergebnisse",
+          "products": "Verkehrsmittel"
         }
       }
     },

--- a/custom_components/vbb/translations/en.json
+++ b/custom_components/vbb/translations/en.json
@@ -21,7 +21,8 @@
         "data": {
           "name": "Name",
           "duration": "Time span (minutes)",
-          "results": "Maximum results"
+          "results": "Maximum results",
+          "products": "Transport types"
         }
       }
     },


### PR DESCRIPTION
## Summary
- forward switch platform and persist selected transport types as options
- expose per-transport switches to toggle products dynamically
- aggregate departures by direction and discover new sensors without reload
- bump integration version to 0.6.0

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c706aa3d7883279aa38ebcc046a2fd