### PR TITLE
Add HACS validation and publication metadata

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,29 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  hassfest:
+    name: Hassfest validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/README.de.md
+++ b/README.de.md
@@ -8,13 +8,12 @@ Dieses Repository stellt eine Home-Assistant Integration bereit, um Abfahrtszeit
 
 ## Installation
 
-Die Integration kann über [HACS](https://hacs.xyz/) installiert werden:
+Die Integration steht als [Standard-Repository in HACS](https://hacs.xyz/) zur Verfügung und kann direkt installiert werden:
 
-1. Füge dieses Repository in HACS als benutzerdefiniertes Repository hinzu.
-2. Suche nach "VBB Public Transport" und installiere die Integration.
-3. Starte Home Assistant neu.
+1. Öffne **HACS → Integrationen** und suche nach **VBB Public Transport**.
+2. Installiere die Integration und starte anschließend Home Assistant neu.
 
-Alternativ kann der Ordner `custom_components/vbb` manuell in das `custom_components` Verzeichnis kopiert werden.
+Alternativ kann der Ordner `custom_components/vbb` manuell in das `custom_components`-Verzeichnis kopiert werden.
 
 ## Konfiguration
 
@@ -33,7 +32,7 @@ Für jede Linie und Zielrichtung an der Haltestelle wird ein eigener Sensor ange
 
 ## Hinweise
 
-Die Integration verwendet die öffentliche API unter `https://v5.vbb.transport.rest/`. Eine funktionierende Internetverbindung ist erforderlich.
+Die Integration verwendet die öffentliche API unter `https://v5.vbb.transport.rest/`. Eine funktionierende Internetverbindung ist erforderlich. Der Dienst deckt ausschließlich Haltestellen in Deutschland (VBB-Gebiet) ab. Home Assistant 2023.12 oder neuer wird benötigt.
 
 Standardmäßig werden Abfahrten für 120 Minuten im Voraus und maximal 100 Ergebnisse abgefragt. Diese Werte lassen sich in der Konfiguration anpassen.
 

--- a/README.en.md
+++ b/README.en.md
@@ -8,11 +8,10 @@ This repository provides a Home Assistant integration that fetches departure tim
 
 ## Installation
 
-The integration can be installed through [HACS](https://hacs.xyz/):
+The integration is available as a [default repository in HACS](https://hacs.xyz/):
 
-1. Add this repository to HACS as a custom repository.
-2. Search for "VBB Public Transport" and install the integration.
-3. Restart Home Assistant.
+1. Open **HACS → Integrations** and search for **VBB Public Transport**.
+2. Install the integration and restart Home Assistant afterwards.
 
 Alternatively, copy the `custom_components/vbb` folder into your `custom_components` directory.
 
@@ -33,7 +32,7 @@ For each line and direction at the stop a separate sensor is created (e.g. `S7 S
 
 ## Notes
 
-The integration uses the public API at `https://v5.vbb.transport.rest/`. An active internet connection is required.
+The integration uses the public API at `https://v5.vbb.transport.rest/`. An active internet connection is required. Service coverage is limited to stops located in Germany (VBB service area). Home Assistant 2023.12 or newer is required.
 
 By default departures for 120 minutes ahead and up to 100 results are queried. These values can be adjusted in the configuration.
 

--- a/README.es.md
+++ b/README.es.md
@@ -8,11 +8,10 @@ Este repositorio ofrece una integración para Home Assistant que obtiene los hor
 
 ## Instalación
 
-La integración puede instalarse a través de [HACS](https://hacs.xyz/):
+La integración está disponible como [repositorio predeterminado en HACS](https://hacs.xyz/):
 
-1. Añade este repositorio como repositorio personalizado en HACS.
-2. Busca "VBB Public Transport" e instala la integración.
-3. Reinicia Home Assistant.
+1. Abre **HACS → Integrations** y busca **VBB Public Transport**.
+2. Instala la integración y reinicia Home Assistant a continuación.
 
 Como alternativa, copia la carpeta `custom_components/vbb` en tu directorio `custom_components`.
 
@@ -33,7 +32,7 @@ Para cada línea y dirección en la parada se crea un sensor separado (p. ej. `S
 
 ## Notas
 
-La integración utiliza la API pública `https://v5.vbb.transport.rest/`. Se requiere una conexión a Internet activa.
+La integración utiliza la API pública `https://v5.vbb.transport.rest/`. Se requiere una conexión a Internet activa. La cobertura del servicio se limita a paradas ubicadas en Alemania (zona del VBB). Se necesita Home Assistant 2023.12 o posterior.
 
 Por defecto se consultan las salidas para los próximos 120 minutos y hasta 100 resultados. Estos valores pueden ajustarse en la configuración.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -8,11 +8,10 @@ Ce dépôt fournit une intégration Home Assistant permettant d'obtenir les hora
 
 ## Installation
 
-L'intégration peut être installée via [HACS](https://hacs.xyz/) :
+L'intégration est disponible en tant que [dépôt par défaut dans HACS](https://hacs.xyz/) :
 
-1. Ajoutez ce dépôt comme dépôt personnalisé dans HACS.
-2. Recherchez « VBB Public Transport » et installez l'intégration.
-3. Redémarrez Home Assistant.
+1. Ouvrez **HACS → Intégrations** et recherchez **VBB Public Transport**.
+2. Installez l'intégration puis redémarrez Home Assistant.
 
 Sinon, copiez le dossier `custom_components/vbb` dans votre répertoire `custom_components`.
 
@@ -33,7 +32,7 @@ Pour chaque ligne et direction à l'arrêt un capteur séparé est créé (par e
 
 ## Remarques
 
-L'intégration utilise l'API publique `https://v5.vbb.transport.rest/`. Une connexion Internet active est nécessaire.
+L'intégration utilise l'API publique `https://v5.vbb.transport.rest/`. Une connexion Internet active est nécessaire. La couverture du service est limitée aux arrêts situés en Allemagne (zone VBB). Home Assistant 2023.12 ou version ultérieure est requis.
 
 Par défaut les départs des 120 prochaines minutes et jusqu'à 100 résultats sont interrogés. Ces valeurs peuvent être ajustées dans la configuration.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Home Assistant integration for public transport departures in Berlin-Brandenburg (VBB).
 
+## Availability
+
+The integration provides data for stops served by the Verkehrsverbund Berlin-Brandenburg and is therefore only relevant for installations located in Germany.
+
+## Installation via HACS
+
+This repository is available as a [default repository in HACS](https://hacs.xyz/). Install it by navigating to **HACS → Integrations**, searching for **VBB Public Transport** and completing the installation flow. Afterwards restart Home Assistant so the integration becomes available under **Settings → Devices & Services → Add Integration**.
+
+The integration requires Home Assistant 2023.12 or newer.
+
 ## Languages
 
 - [Deutsch](README.de.md)

--- a/README.pl.md
+++ b/README.pl.md
@@ -8,11 +8,10 @@ To repozytorium udostępnia integrację Home Assistant, która pobiera czasy odj
 
 ## Instalacja
 
-Integrację można zainstalować przez [HACS](https://hacs.xyz/):
+Integrację można zainstalować jako [repozytorium domyślne w HACS](https://hacs.xyz/):
 
-1. Dodaj to repozytorium jako repozytorium niestandardowe w HACS.
-2. Wyszukaj "VBB Public Transport" i zainstaluj integrację.
-3. Uruchom ponownie Home Assistant.
+1. Otwórz **HACS → Integrations** i wyszukaj **VBB Public Transport**.
+2. Zainstaluj integrację i uruchom ponownie Home Assistant.
 
 Alternatywnie skopiuj folder `custom_components/vbb` do swojego katalogu `custom_components`.
 
@@ -33,7 +32,7 @@ Dla każdej linii i kierunku na przystanku tworzony jest osobny sensor (np. `S7 
 
 ## Uwagi
 
-Integracja korzysta z publicznego API `https://v5.vbb.transport.rest/`. Wymagane jest aktywne połączenie z Internetem.
+Integracja korzysta z publicznego API `https://v5.vbb.transport.rest/`. Wymagane jest aktywne połączenie z Internetem. Usługa obejmuje wyłącznie przystanki w Niemczech (obszar VBB). Wymagany jest Home Assistant 2023.12 lub nowszy.
 
 Domyślnie pobierane są odjazdy na 120 minut do przodu i maksymalnie 100 wyników. Wartości te można dostosować w konfiguracji.
 

--- a/custom_components/vbb/manifest.json
+++ b/custom_components/vbb/manifest.json
@@ -2,9 +2,12 @@
   "domain": "vbb",
   "name": "VBB Public Transport",
   "version": "0.6.0",
-  "documentation": "https://github.com/username/HA-Public-Transport-VBB",
+  "documentation": "https://github.com/404GamerNotFound/HA-Public-Transport-VBB",
+  "issue_tracker": "https://github.com/404GamerNotFound/HA-Public-Transport-VBB/issues",
   "requirements": [],
-  "codeowners": ["@nobody"],
+  "codeowners": ["@404GamerNotFound"],
   "config_flow": true,
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_polling",
+  "country": ["DE"],
+  "integration_type": "service"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,10 @@
 {
   "name": "VBB Public Transport",
   "hacs_version": "1.0.0",
+  "homeassistant": "2023.12.0",
   "domains": ["vbb"],
   "render_readme": true,
+  "content_in_root": false,
+  "country": ["DE"],
   "codeowners": ["404GamerNotFound"]
 }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running hassfest and HACS validation for every push and pull request
- update integration manifest and hacs.json with publication metadata, German availability, and minimum Home Assistant requirement
- refresh documentation in all supported languages to describe default HACS installation and German-only coverage

## Testing
- python -m compileall custom_components/vbb

------
https://chatgpt.com/codex/tasks/task_e_68ca8f028ef08327900aabab4724d7ff