### PR TITLE
Remove unsupported country key from VBB manifest

### DIFF
--- a/custom_components/vbb/manifest.json
+++ b/custom_components/vbb/manifest.json
@@ -8,6 +8,5 @@
   "codeowners": ["@404GamerNotFound"],
   "config_flow": true,
   "iot_class": "cloud_polling",
-  "country": ["DE"],
   "integration_type": "service"
 }


### PR DESCRIPTION
## Summary
- remove the unsupported `country` field from the VBB integration manifest to satisfy Home Assistant validation

## Testing
- python3 -m compileall custom_components/vbb

------
https://chatgpt.com/codex/tasks/task_e_68caa9de68f48327af472a8cfac12318