### PR TITLE
Keep last departure state during API outages

### DIFF
--- a/custom_components/vbb/sensor.py
+++ b/custom_components/vbb/sensor.py
@@ -295,7 +295,7 @@ class VbbDepartureSensor(SensorEntity):
                 self._session, API_PATH.format(station=self._station_id), params
             )
         except Exception:
-            self._attr_available = False
+            # Keep the last successful state when the API is temporarily unreachable.
             return
 
         self._attr_available = True
@@ -414,7 +414,7 @@ class VbbStationSensor(SensorEntity):
                 self._session, API_PATH.format(station=self._station_id), params
             )
         except Exception:
-            self._attr_available = False
+            # Keep the last successful state when the API is temporarily unreachable.
             return
 
         departures: list[tuple[datetime, dict[str, Any]]] = []
@@ -510,7 +510,7 @@ class VbbDirectionSensor(SensorEntity):
                 self._session, API_PATH.format(station=self._station_id), params
             )
         except Exception:
-            self._attr_available = False
+            # Keep the last successful state when the API is temporarily unreachable.
             return
 
         self._attr_available = True


### PR DESCRIPTION
### Motivation
- Prevent VBB sensors from switching to `unavailable` when the remote API is temporarily unreachable.  
- Preserve the last successful departure timestamp and attributes so entity cards continue to show the previous schedule instead of an unavailable state.

### Description
- In `VbbDepartureSensor.async_update`, `VbbStationSensor.async_update`, and `VbbDirectionSensor.async_update` stop setting `self._attr_available = False` on any API exception and instead return early to keep the last successful state.  
- Added an English inline comment explaining the fallback: `# Keep the last successful state when the API is temporarily unreachable.`  
- Changes are limited to `custom_components/vbb/sensor.py` around the API request `except Exception` handlers for the three sensor types.

### Testing
- Compiled the modified module with `python -m compileall custom_components/vbb/sensor.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac35d67988327a3ca18d453370121)